### PR TITLE
Allow to pass connection object

### DIFF
--- a/lib/sequel/rake/tasks.rake
+++ b/lib/sequel/rake/tasks.rake
@@ -58,10 +58,10 @@ namespace Sequel::Rake.get(:namespace) do
   end
 
   def connection
-    if Sequel::Rake.get(:connection).is_a?(String)
-      @connection ||= Sequel.connect(Sequel::Rake.get(:connection))
-    else
+    if Sequel::Rake.get(:connection).is_a?(Sequel::Database)
       Sequel::Rake.get(:connection)
+    else
+      @connection ||= Sequel.connect(Sequel::Rake.get(:connection))
     end
   end
 

--- a/lib/sequel/rake/tasks.rake
+++ b/lib/sequel/rake/tasks.rake
@@ -58,7 +58,11 @@ namespace Sequel::Rake.get(:namespace) do
   end
 
   def connection
-    @connection ||= Sequel.connect(Sequel::Rake.get(:connection))
+    if Sequel::Rake.get(:connection).is_a?(String)
+      @connection ||= Sequel.connect(Sequel::Rake.get(:connection))
+    else
+      Sequel::Rake.get(:connection)
+    end
   end
 
   def migrations


### PR DESCRIPTION
Allow to pass connection object in configuration instead of connection string. For example `Rakefile`
```ruby
require File.join(File.dirname(__FILE__), %w{config boot})
require File.join(File.dirname(__FILE__), %w{config initializers sequel})

require 'sequel/rake'
Sequel::Rake.configure do
  set :connection, App.db # App.db was initialized in sequel.rb
  set :migrations, "#{__dir__}/db/migrations"
  set :namespace, 'db'
end
Sequel::Rake.load!
```